### PR TITLE
Update Brush to also allow Cross-Origin images.

### DIFF
--- a/src/Brush.ts
+++ b/src/Brush.ts
@@ -68,6 +68,7 @@ export default class Brush {
   static generateBrush (imgSrc: string): HTMLImageElement {
     if (imgSrc.length !== 0) {
       let brush = new Image();
+      brush.crossOrigin = 'Anonymous'; // Works only if the server response headers contains [Access-Control-Allow-Origin: *]
       brush.src = imgSrc;
       return brush;
     } else {


### PR DESCRIPTION
Chrome and Firefox now give an error when setting the Brush to a cross origin image. Copied your code over from util.js that sets the `.crossOrigin` property which should fix the issue.