### PR TITLE
Fix types for TS files using ScratchCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.4",
   "description": "Create scratch card in browser.",
   "main": "./build/scratchcard.min.js",
+  "typings": "./types/scratchcard-js.d.ts",
   "scripts": {
     "dev": "cross-env NODE_ENV=development concurrently \"webpack\" \"webpack-dev-server\" ",
     "build": "webpack",


### PR DESCRIPTION
Actually, if you install the package and import it in a TS file, the types are not detected by Typescript and generate errors.

`package.json` was missing the option `typings` to tell TS where to find the types.